### PR TITLE
Enable folder deletions

### DIFF
--- a/BunnyCDN/Storage.py
+++ b/BunnyCDN/Storage.py
@@ -163,10 +163,10 @@ class Storage:
 
     def DeleteFile(self, storage_path=""):
         """
-        This function deletes a file mentioned in the storage_path from the storage zone
+        This function deletes a file or folder mentioned in the storage_path from the storage zone
         Parameters
         ----------
-        storage_path : The directory path to your file(including file name) which is to be deleted.
+        storage_path : The directory path to your file (including file name) or folder which is to be deleted.
                        If this is the root of your storage zone, you can ignore this parameter.
         """
         # Add code below
@@ -176,8 +176,6 @@ class Storage:
         # to build correct url
         if storage_path[0] == "/":
             storage_path = storage_path[1:]
-        if storage_path[-1] == "/":
-            storage_path = storage_path[:-1]
         url = self.base_url + parse.quote(storage_path)
 
         try:

--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ Storage module has functions that utilize APIs mentioned in official Bunnycdn st
     The storage_path here does not include storage zone name and it should end with the desired file name to be stored in storage zone.(example: 'sample_dir/abc.txt')
     
     The local_upload_file_path is the path of the file in the local PC excluding file name
-* ### Delete File
-    To delete a file from a specific directory in storage zone
+* ### Delete File/Folder
+    To delete a file or folder from a specific directory in storage zone
     ```
     >>obj_storage.DeleteFile(storage_path)
     ```
+    If deleting a folder, make sure the storage_path ends with a trailing slash "/".  
+    Deleting a folder will delete all files within it.
 * ### Get Storaged Objects List
     Returns a list containing name of all the files and folders in the directory specified in storage path
     ```


### PR DESCRIPTION
As it stands, only files can be deleted.
Bunny's API allows for folder deletions but the storage path has to end with a trailing slash in order to work.