### PR TITLE
Update CDN API class default base_url

### DIFF
--- a/BunnyCDN/CDN.py
+++ b/BunnyCDN/CDN.py
@@ -22,7 +22,7 @@ class CDN:
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
-        self.base_url = "https://bunnycdn.com/api/"
+        self.base_url = "https://api.bunny.net/"
 
     def _Geturl(self, Task_name):
         """

--- a/BunnyCDN/CDN.py
+++ b/BunnyCDN/CDN.py
@@ -1,4 +1,4 @@
-# from https://github.com/mathrithms/BunnyCDN-Python-Lib/blob/master/BunnyCDN/CDN.py 
+# from https://github.com/mathrithms/BunnyCDN-Python-Lib/blob/master/BunnyCDN/CDN.py
 import json
 import requests
 from requests.exceptions import HTTPError
@@ -8,7 +8,6 @@ from urllib import parse
 class CDN:
     # initializer function
     def __init__(self, api_key):
-
         """
         Parameters
         ----------
@@ -22,7 +21,7 @@ class CDN:
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
-        self.base_url = "https://bunnycdn.com/api/"
+        self.base_url = "https://api.bunny.net/"
 
     def _Geturl(self, Task_name):
         """
@@ -41,11 +40,7 @@ class CDN:
             url = self.base_url + parse.quote(Task_name)
         return url
 
-    def AddCertificate(self,
-                       PullZoneId,
-                       Hostname,
-                       Certificate,
-                       CertificateKey):
+    def AddCertificate(self, PullZoneId, Hostname, Certificate, CertificateKey):
         """
         This function adds custom certificate to the given pullzone
 
@@ -83,13 +78,9 @@ class CDN:
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "success",
@@ -110,25 +101,17 @@ class CDN:
         BlockedIP       : string
                           The IP address that will be blocked
         """
-        values = json.dumps(
-            {"PullZoneId": PullZoneId,
-             "BlockedIp": BlockedIp}
-            )
+        values = json.dumps({"PullZoneId": PullZoneId, "BlockedIp": BlockedIp})
 
         try:
             response = requests.post(
-                self._Geturl("pullzone/addBlockedIp"), data=values,
-                headers=self.headers
+                self._Geturl("pullzone/addBlockedIp"), data=values, headers=self.headers
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "success",
@@ -159,18 +142,14 @@ class CDN:
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "success",
                 "HTTP": response.status_code,
-                "msg": "Ip removed from blocked IPs list "
+                "msg": "Ip removed from blocked IPs list ",
             }
 
     def StorageZoneData(self):
@@ -180,17 +159,12 @@ class CDN:
 
         """
         try:
-            response = requests.get(self._Geturl("storagezone"),
-                                    headers=self.headers)
+            response = requests.get(self._Geturl("storagezone"), headers=self.headers)
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             storage_summary = []
             for storagezone in response.json():
@@ -215,17 +189,12 @@ class CDN:
         name and storage zone id
         """
         try:
-            response = requests.get(self._Geturl("storagezone"),
-                                    headers=self.headers)
+            response = requests.get(self._Geturl("storagezone"), headers=self.headers)
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             storage_list = []
             for storagezone in response.json():
@@ -233,8 +202,7 @@ class CDN:
             return storage_list
 
     def AddStorageZone(
-        self, storage_zone_name, storage_zone_region="DE",
-        ReplicationRegions=["DE"]
+        self, storage_zone_name, storage_zone_region="DE", ReplicationRegions=["DE"]
     ):
         """
         This method creates a new storage zone
@@ -275,13 +243,9 @@ class CDN:
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "success",
@@ -290,7 +254,6 @@ class CDN:
             }
 
     def GetStorageZone(self, storage_zone_id):
-
         """
         This function returns details about the storage zone
         whose id is mentioned
@@ -303,18 +266,13 @@ class CDN:
         """
         try:
             response = requests.get(
-                self._Geturl(f"storagezone/{storage_zone_id}"),
-                headers=self.headers
+                self._Geturl(f"storagezone/{storage_zone_id}"), headers=self.headers
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return response.json()
 
@@ -329,18 +287,13 @@ class CDN:
         """
         try:
             response = requests.delete(
-                self._Geturl(f"storagezone/{storage_zone_id}"),
-                headers=self.headers
+                self._Geturl(f"storagezone/{storage_zone_id}"), headers=self.headers
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "Success",
@@ -360,18 +313,13 @@ class CDN:
         """
         try:
             response = requests.post(
-                self._Geturl("purge"), params={"url": url},
-                headers=self.headers
+                self._Geturl("purge"), params={"url": url}, headers=self.headers
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "Success",
@@ -385,17 +333,12 @@ class CDN:
 
         """
         try:
-            response = requests.get(self._Geturl("billing"),
-                                    headers=self.headers)
+            response = requests.get(self._Geturl("billing"), headers=self.headers)
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return response.json()
 
@@ -416,13 +359,9 @@ class CDN:
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "success",
@@ -479,13 +418,9 @@ class CDN:
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return response.json()
 
@@ -498,17 +433,12 @@ class CDN:
         None
         """
         try:
-            response = requests.get(self._Geturl("pullzone"),
-                                    headers=self.headers)
+            response = requests.get(self._Geturl("pullzone"), headers=self.headers)
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             pullzone_list = []
             for pullzone in response.json():
@@ -539,11 +469,7 @@ class CDN:
         """
 
         if StorageZoneId is None:
-            values = json.dumps(
-                {"Name": Name,
-                 "Type": Type,
-                 "OriginURL": OriginURL}
-                )
+            values = json.dumps({"Name": Name, "Type": Type, "OriginURL": OriginURL})
         else:
             values = {
                 "Name": Name,
@@ -557,13 +483,9 @@ class CDN:
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return response.json()
 
@@ -583,13 +505,9 @@ class CDN:
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return response.json()
 
@@ -870,17 +788,13 @@ class CDN:
             response = requests.post(
                 self._Geturl(f"pullzone/{PullZoneID}"),
                 data=values,
-                headers=self.headers
+                headers=self.headers,
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "success",
@@ -904,13 +818,9 @@ class CDN:
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "success",
@@ -930,18 +840,13 @@ class CDN:
         """
         try:
             response = requests.post(
-                self._Geturl(f"pullzone/{PullZoneID}/purgeCache"),
-                headers=self.headers
+                self._Geturl(f"pullzone/{PullZoneID}/purgeCache"), headers=self.headers
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "success",
@@ -962,7 +867,6 @@ class CDN:
         GUID=None,
         ExtraActions=None,
     ):
-
         """
         This function Adds or Updates the Edgerule
 
@@ -1009,13 +913,13 @@ class CDN:
         """
         success_msg = "successfully added edgerule"
         request_payload = {
-                "ActionParameter1": ActionParameter1,
-                "ActionParameter2": ActionParameter2,
-                "Enabled": Enabled,
-                "Description": Description,
-                "ActionType": ActionType,
-                "TriggerMatchingType": TriggerMatchingType,
-                "Triggers": Triggers,
+            "ActionParameter1": ActionParameter1,
+            "ActionParameter2": ActionParameter2,
+            "Enabled": Enabled,
+            "Description": Description,
+            "ActionType": ActionType,
+            "TriggerMatchingType": TriggerMatchingType,
+            "Triggers": Triggers,
         }
         if GUID:
             request_payload["GUID"] = GUID
@@ -1030,20 +934,15 @@ class CDN:
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "success",
                 "HTTP": response.status_code,
                 "msg": success_msg,
             }
-
 
     def DeleteEdgeRule(self, PullZoneID, EdgeRuleID):
         """
@@ -1065,13 +964,9 @@ class CDN:
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "success",
@@ -1099,17 +994,13 @@ class CDN:
             response = requests.post(
                 self._Geturl(f"pullzone/{PullZoneID}/addHostname"),
                 data=values,
-                headers=self.headers
+                headers=self.headers,
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "success",
@@ -1118,7 +1009,6 @@ class CDN:
             }
 
     def DeleteCustomHostname(self, PullZoneID, Hostname):
-
         """
         This function is used to delete custom hostname of a pullzone
 
@@ -1141,13 +1031,9 @@ class CDN:
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "success",
@@ -1174,25 +1060,18 @@ class CDN:
                              to the SSL version of the URLs
 
         """
-        values = json.dumps(
-            {"Hostname": Hostname,
-             "ForceSSL": ForceSSL}
-        )
+        values = json.dumps({"Hostname": Hostname, "ForceSSL": ForceSSL})
         try:
             response = requests.post(
                 self._Geturl(f"pullzone/{PullZoneID}/setForceSSL"),
                 data=values,
-                headers=self.headers
+                headers=self.headers,
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return {
                 "status": "success",
@@ -1215,23 +1094,19 @@ class CDN:
         try:
             response = requests.get(
                 self._Geturl("pullzone/loadFreeCertificate"),
-                params={'hostname': Hostname},
+                params={"hostname": Hostname},
                 headers=self.headers,
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
             return self.GetPullZoneList()
 
     def GetVideoLibrary(self, id):
-        '''
+        """
         Returns the Video Library details for the given ID
 
         Parameters
@@ -1239,52 +1114,47 @@ class CDN:
         id       :  number
                     The ID of the Video Library to return
 
-        '''
+        """
         try:
             response = requests.get(
-             self._Geturl("videolibrary"), params={'id': id},
-             headers=self.headers,
+                self._Geturl("videolibrary"),
+                params={"id": id},
+                headers=self.headers,
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
-            return {"status": "success",
-                    "HTTP": response.status_code,
-                    "msg": response.json()
-                    }
+            return {
+                "status": "success",
+                "HTTP": response.status_code,
+                "msg": response.json(),
+            }
 
     def DeleteVideoLibrary(self, id):
-        '''
+        """
         Deletes the Video Library with the given ID
 
         Parameters
         ----------
         id      : number
                   The ID of the library that should be deleted
-        '''
+        """
         try:
             response = requests.delete(
-             self._Geturl(f"videolibrary/{id}"),
-             headers=self.headers,
+                self._Geturl(f"videolibrary/{id}"),
+                headers=self.headers,
             )
             response.raise_for_status()
         except HTTPError as http:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": http}
+            return {"status": "error", "HTTP": response.status_code, "msg": http}
         except Exception as err:
-            return {"status": "error",
-                    "HTTP": response.status_code,
-                    "msg": err}
+            return {"status": "error", "HTTP": response.status_code, "msg": err}
         else:
-            return {"status": "success",
-                    "HTTP": response.status_code,
-                    "msg": "Deleted Video Library"
-                    }
+            return {
+                "status": "success",
+                "HTTP": response.status_code,
+                "msg": "Deleted Video Library",
+            }


### PR DESCRIPTION
It looks like https://bunnycdn.com/api/billing was removed, as the endpoint returns 404's instead of 401 when no access key is provided. [Current bunnycdn api documentation](https://docs.bunny.net/reference/bunnynet-api-overview) suggests the current production api endpoint was moved to https://api.bunny.net/ ~two weeks ago. Overriding `base_url` manually after creating a `CDN` object seems to return correct billing data.

I smoke tested a couple of the other methods via curl/browser and they seem to point to valid api endpoints, but I didn't test their corresponding methods in this library. This should probably be further tested before merging. 
